### PR TITLE
Stm32 support

### DIFF
--- a/psdb/component/component.py
+++ b/psdb/component/component.py
@@ -102,6 +102,18 @@ class Component(object):
 
         return None
 
+    def _find_components_by_type(self, typ, results):
+        if isinstance(self, typ):
+            results.append(self)
+
+        for c in self.children:
+            c._find_components_by_type(typ, results)
+
+    def find_components_by_type(self, typ):
+        results = []
+        self._find_components_by_type(typ, results)
+        return results
+
     def dump(self, prefix=''):
         print('%s%s' % (prefix, self))
         for c in self.children:

--- a/psdb/cpus/__init__.py
+++ b/psdb/cpus/__init__.py
@@ -2,11 +2,16 @@
 import psdb.component
 from . import cortex
 from . import cortex_m4
+from . import cortex_m7
 
+
+# Cortex-M7 as defined in the ARM spec.
+psdb.component.Matcher(cortex_m7.CortexM7, 0xB105100D, 0x00000004000BB4C8,
+                       subtype='Cortex-M7')
 
 # It's common practice for third-party vendors to put their own identifying
 # information in the top-level Cortex ROM Table.  It's implied that this is
-# normal in the Cortex-M4 spec.
+# normal in the Cortex-M4 spec, although the Cortex-M7 spec is silent about it.
 psdb.component.StaticMatcher(cortex_m4.CortexM4, 0, 0xE00FF000, 0xB105100D,
                              0x000000000B1979AF,
                              subtype='MSP432P401R Cortex-M4')

--- a/psdb/cpus/__init__.py
+++ b/psdb/cpus/__init__.py
@@ -15,6 +15,8 @@ psdb.component.Matcher(cortex_m7.CortexM7, 0xB105100D, 0x00000004000BB4C8,
 psdb.component.StaticMatcher(cortex_m4.CortexM4, 0, 0xE00FF000, 0xB105100D,
                              0x000000000B1979AF,
                              subtype='MSP432P401R Cortex-M4')
+psdb.component.StaticMatcher(cortex_m7.CortexM7, 0, 0xE00FE000, 0xB105100D,
+                             0x00000000000A0450, subtype='STM32H7 Cortex-M7')
 
 # Matcher for the Cortex System Control Block.  This is matched in order to
 # enable DEMCR.TRCENA so that child tables can be probed properly.  It's also

--- a/psdb/cpus/__init__.py
+++ b/psdb/cpus/__init__.py
@@ -15,6 +15,8 @@ psdb.component.Matcher(cortex_m7.CortexM7, 0xB105100D, 0x00000004000BB4C8,
 psdb.component.StaticMatcher(cortex_m4.CortexM4, 0, 0xE00FF000, 0xB105100D,
                              0x000000000B1979AF,
                              subtype='MSP432P401R Cortex-M4')
+psdb.component.StaticMatcher(cortex_m4.CortexM4, 0, 0xE00FF000, 0xB105100D,
+                             0x00000000000A0469, subtype='STM32G4 Cortex-M4')
 psdb.component.StaticMatcher(cortex_m7.CortexM7, 0, 0xE00FE000, 0xB105100D,
                              0x00000000000A0450, subtype='STM32H7 Cortex-M7')
 

--- a/psdb/cpus/cortex.py
+++ b/psdb/cpus/cortex.py
@@ -54,8 +54,19 @@ class Cortex(psdb.component.Component):
     def __init__(self, component, subtype):
         super(Cortex, self).__init__(component.parent, component.ap,
                                      component.addr, subtype)
+        self._scb  = None
         self.flags = 0
         self.ap.db.cpus.append(self)
+
+    @property
+    def scb(self):
+        if not self._scb:
+            results = self.find_components_by_type(SystemControlBlock)
+            assert results
+            assert len(results) == 1
+            self._scb = results[0]
+
+        return self._scb
 
     def is_halted(self):
         return self.flags & FLAG_HALTED
@@ -73,16 +84,16 @@ class Cortex(psdb.component.Component):
         return self.ap.read_bulk(addr, size)
 
     def read_aircr(self):
-        return self.ap.read_32(0xE000ED0C)
+        return self.ap.read_32(self.scb.addr + 0xD0C)
 
     def read_dhcsr(self):
-        return self.ap.read_32(0xE000EDF0)
+        return self.ap.read_32(self.scb.addr + 0xDF0)
 
     def read_dcrdr(self):
-        return self.ap.read_32(0xE000EDF8)
+        return self.ap.read_32(self.scb.addr + 0xDF8)
 
     def read_demcr(self):
-        return self.ap.read_32(0xE000EDFC)
+        return self.ap.read_32(self.scb.addr + 0xDFC)
 
     def _read_core_register(self, sel):
         assert self.flags & FLAG_HALTED
@@ -117,19 +128,19 @@ class Cortex(psdb.component.Component):
         self.ap.write_bulk(data, addr)
 
     def write_aircr(self, v):
-        return self.ap.write_32(v, 0xE000ED0C)
+        return self.ap.write_32(v, self.scb.addr + 0xD0C)
 
     def write_dhcsr(self, v):
-        return self.ap.write_32(v, 0xE000EDF0)
+        return self.ap.write_32(v, self.scb.addr + 0xDF0)
 
     def write_dcrsr(self, v):
-        return self.ap.write_32(v, 0xE000EDF4)
+        return self.ap.write_32(v, self.scb.addr + 0xDF4)
 
     def write_dcrdr(self, v):
-        return self.ap.write_32(v, 0xE000EDF8)
+        return self.ap.write_32(v, self.scb.addr + 0xDF8)
 
     def write_demcr(self, v):
-        return self.ap.write_32(v, 0xE000EDFC)
+        return self.ap.write_32(v, self.scb.addr + 0xDFC)
 
     def write_core_register(self, v, sel):
         '''Writes a single core register.'''

--- a/psdb/cpus/cortex_m7.py
+++ b/psdb/cpus/cortex_m7.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2018-2019 Phase Advanced Sensor Systems, Inc.
+from . import cortex
+
+class CortexM7(cortex.Cortex):
+    def __init__(self, component, subtype):
+        super(CortexM7, self).__init__(component, subtype)

--- a/psdb/flash_tool.py
+++ b/psdb/flash_tool.py
@@ -28,6 +28,11 @@ def main(rv):
     # Halt the target.
     target.halt()
 
+    # Flash info if verbose.
+    if rv.verbose:
+        print('       Flash size: %u' % target.flash.flash_size)
+        print('Flash sector size: %u' % target.flash.sector_size)
+
     # Read a backup of flash if requested.
     if rv.read_flash:
         with open(rv.read_flash, 'wb') as f:

--- a/psdb/flash_tool.py
+++ b/psdb/flash_tool.py
@@ -25,9 +25,6 @@ def main(rv):
     # Use the probe to detect a target platform.
     target = probe.probe(verbose=rv.verbose)
 
-    # Halt the target.
-    target.halt()
-
     # Flash info if verbose.
     if rv.verbose:
         print('       Flash size: %u' % target.flash.flash_size)

--- a/psdb/gdb_tool.py
+++ b/psdb/gdb_tool.py
@@ -242,6 +242,7 @@ def main(rv):
     print('Starting server on port %s for %s' % (rv.port, probe))
     probe.set_tck_freq_max()
     target = probe.probe(verbose=rv.verbose)
+    target.resume()
     GDBServer(target, rv.port, rv.verbose)
 
     while True:

--- a/psdb/inspect_tool.py
+++ b/psdb/inspect_tool.py
@@ -213,6 +213,9 @@ if __name__ == '__main__':
 
     # Probe the target platform.
     args.target = args.probe.probe(verbose=args.verbose)
-    args.target.halt()
 
+    # Interact with the UI.
     tgcurses.wrapper(main, args)
+
+    # Resume the target.
+    args.target.resume()

--- a/psdb/inspect_tool.py
+++ b/psdb/inspect_tool.py
@@ -50,11 +50,11 @@ def draw_dev_registers(reg_win, dev):
 
 def draw_mem_dump(mem_win, dev):
     if not dev.regs and hasattr(dev, 'size'):
-        dev._mem_dump_addr = dev.__dict__.get('_mem_dump_addr', dev.base)
+        dev._mem_dump_addr = dev.__dict__.get('_mem_dump_addr', dev.dev_base)
         mem_win.show()
         rows = mem_win.content.height
         addr = dev._mem_dump_addr
-        size = min(32*rows, dev.size - (addr - dev.base))
+        size = min(32*rows, dev.size - (addr - dev.dev_base))
         data = dev.read_mem_block(dev._mem_dump_addr, size)
         rows = int(math.ceil(size / 32.))
         for i in range(rows):
@@ -91,19 +91,19 @@ def draw_device(reg_win, mem_win, dev):
 
 
 def mem_up(reg_win, mem_win, d, n):
-    avail = d._mem_dump_addr - d.base
+    avail = d._mem_dump_addr - d.dev_base
     d._mem_dump_addr -= min(avail, n)
     draw_device(reg_win, mem_win, d)
 
 
 def mem_down(reg_win, mem_win, d, n):
-    avail = d.base + d.size - d._mem_dump_addr
+    avail = d.dev_base + d.size - d._mem_dump_addr
     d._mem_dump_addr += min(avail, n)
-    if d._mem_dump_addr >= d.base + d.size:
-        d._mem_dump_addr = d.base + d.size - 32
+    if d._mem_dump_addr >= d.dev_base + d.size:
+        d._mem_dump_addr = d.dev_base + d.size - 32
     d._mem_dump_addr &= ~31
-    if d._mem_dump_addr < d.base:
-        d._mem_dump_addr = d.base
+    if d._mem_dump_addr < d.dev_base:
+        d._mem_dump_addr = d.dev_base
     draw_device(reg_win, mem_win, d)
 
 
@@ -135,8 +135,8 @@ def main(screen, args):
     t = args.target
 
     # Get the device list.
-    devs         = sorted(t.devs.values(), key=lambda d:d.base)
-    dev_names    = ['%08X %s' % (d.base, d.name) for d in devs]
+    devs         = sorted(t.devs.values(), key=lambda d:d.dev_base)
+    dev_names    = ['%08X %s' % (d.dev_base, d.name) for d in devs]
     max_dev_name = max(len(dn) for dn in dev_names)
     max_reg_name = max(len(r.name) for d in devs for r in d.regs)
 

--- a/psdb/probes/__init__.py
+++ b/psdb/probes/__init__.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2018-2019 Phase Advanced Sensor Systems, Inc.
 from . import xds110
+from . import stlink_v2_1
 from .probe import Exception
 
 
-PROBES = xds110.enumerate()
+PROBES = xds110.enumerate() + stlink_v2_1.enumerate()
 
 def find_by_serial_number(serial_number):
     p = [p for p in PROBES if p.serial_num == serial_number]

--- a/psdb/probes/__init__.py
+++ b/psdb/probes/__init__.py
@@ -30,5 +30,12 @@ def find_default(serial_number=None, usb_path=None):
     elif usb_path:
         return find_by_path(usb_path)
     elif PROBES:
-        return PROBES[0]
+        if len(PROBES) == 1:
+            return PROBES[0]
+
+        print('Found probes:')
+        for p in PROBES:
+            p.show_info()
+        raise Exception('Multiple probes found.')
+
     raise Exception('No compatible debug probe found.')

--- a/psdb/probes/stlink_v2_1.py
+++ b/psdb/probes/stlink_v2_1.py
@@ -1,0 +1,395 @@
+# Copyright (c) 2018-2019 Phase Advanced Sensor Systems, Inc.
+import usb
+from . import usb_probe
+from . import probe
+import psdb
+
+from struct import pack, unpack, unpack_from
+from builtins import bytes, range
+import time
+
+
+RX_EP    = 0x81
+TX_EP    = 0x01
+TRACE_EP = 0x82
+
+SG_SIZE   = 31
+DATA_SIZE = 4096
+
+MODE_EXIT_CMD = {0x00: bytes(b'\xF3\x07'), # DFU
+                 0x02: bytes(b'\xF2\x21'), # DEBUG
+                 0x03: bytes(b'\xF4\x01'), # SWIM
+                 }
+
+# Unknown commands sniffed via debugger:
+# --------------------------------------------------------
+#   Req: f2 4b 00 01 00 00 00 00 00 00 00 00 00 00 00 00
+#              AP
+#   Rsp: 80 00
+# --------------------------------------------------------
+# Typically executed after READMEM_32BIT (0xF2 0x07) and
+# WRITEMEM_32BIT (0xF2 0x08)
+#   Req: f2 3e 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+#   Rsp: 80 00 00 00 00 00 00 00 00 00 00 00
+# --------------------------------------------------------
+#   Req: f2 4c 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+#              AP
+#   Rsp: 80 00
+# --------------------------------------------------------
+
+class STLinkV2_1(usb_probe.Probe):
+    '''
+    STLink V2.1 debug probe.  This can be found on the Nucleo 144 board we have
+    for the STM32H7xx chip.  The USART3 device from the MCU is connected to the
+    debug probe as a virtual COM port.
+    '''
+    def __init__(self, usb_dev):
+        super(STLinkV2_1, self).__init__(usb_dev, 'STLink')
+        self._usb_version()
+        self.dpidr = None
+
+    def _usb_xfer_in(self, cmd, size):
+        cmd = cmd + bytes(b'\x00'*(16 - len(cmd)))
+        assert len(cmd) == 16
+        assert self.usb_dev.write(TX_EP, cmd) == len(cmd)
+        if size is None:
+            return self.usb_dev.read(RX_EP, DATA_SIZE, timeout=1000)
+        rsp = self.usb_dev.read(RX_EP, size, timeout=1000)
+        assert len(rsp) == size
+        return rsp
+
+    def _usb_last_xfer_status(self):
+        assert self.usb_dev.write(TX_EP, bytes(b'\xF2\x3B')) == 2
+        rsp = self.usb_dev.read(RX_EP, 2, timeout=1000)
+        assert len(rsp) == 2
+        return rsp
+
+    def _usb_weird_xfer_status(self):
+        assert self.usb_dev.write(TX_EP, bytes(b'\xF2\x3E')) == 2
+        rsp = self.usb_dev.read(RX_EP, 12, timeout=1000)
+        assert len(rsp) == 12
+        return rsp
+
+    def _usb_xfer_out(self, cmd, data):
+        cmd = cmd + bytes(b'\x00'*(16 - len(cmd)))
+        assert len(cmd) == 16
+        assert self.usb_dev.write(TX_EP, cmd) == len(cmd)
+        assert self.usb_dev.write(TX_EP, data, timeout=1000) == len(data)
+        assert self._usb_last_xfer_status()[0] == 0x80
+
+    def _usb_xfer_null(self, cmd):
+        cmd = cmd + bytes(b'\x00'*(16 - len(cmd)))
+        assert len(cmd) == 16
+        assert self.usb_dev.write(TX_EP, cmd) == len(cmd)
+
+    def _cmd_allow_retry(self, cmd, size):
+        for _ in range(10):
+            data = self._usb_xfer_in(cmd, size)
+            if data[0] == 0x80:
+                return data
+
+            if data[0] not in (0x10, 0x14):
+                raise Exception('Unexpected error 0x%02X: %s' % (data[0], data))
+            time.sleep(0.1)
+        raise Exception('Max retries exceeded!')
+
+    def _usb_version(self):
+        rsp = self._usb_xfer_in(bytes(b'\xF1'), 6)
+        v0, v1, vid, pid = unpack('<BBHH', rsp)
+        v = (v0 << 8) | v1
+        self.ver_stlink = (v >> 12) & 0x0F
+        self.ver_jtag   = (v >>  6) & 0x3F
+        self.ver_swim   = (v >>  0) & 0x3F
+        self.ver_vid    = vid
+        self.ver_pid    = pid
+        assert self.ver_vid == 0x0483
+        assert self.ver_pid == 0x374B
+
+    def _read_dpidr(self, suffix=bytes(b'')):
+        rsp = self._usb_xfer_in(bytes(b'\xF2\x22') + suffix, 4)
+        return unpack('<I', rsp)[0]
+
+    def _read_idcodes(self, suffix=bytes(b'')):
+        rsp = self._usb_xfer_in(bytes(b'\xF2\x31') + suffix, None)
+        return unpack('<III', rsp)
+
+    def _current_mode(self):
+        rsp = self._usb_xfer_in(bytes(b'\xF5'), 2)
+        return rsp[0]
+
+    def _mode_leave(self, mode):
+        cmd = MODE_EXIT_CMD.get(mode)
+        if cmd:
+            self._usb_xfer_null(cmd)
+
+    def _leave_current_mode(self):
+        self._mode_leave(self._current_mode())
+
+    def _swd_connect(self):
+        # Switch to SWD mode.
+        self._leave_current_mode()
+        self._cmd_allow_retry(bytes(b'\xF2\x30\xA3'), 2)
+        assert self._current_mode() == 0x02
+
+    def _set_swdclk_divisor(self, divisor):
+        assert self.ver_stlink > 1
+        assert self.ver_jtag >= 22
+        cmd = pack('<BBH', 0xF2, 0x43, divisor)
+        self._cmd_allow_retry(cmd, 2)
+
+    def _bulk_read_8(self, addr, n, ap_num=0):
+        '''
+        Reads a consecutive number of bytes from the specified address.
+        '''
+        assert n <= 64
+        if not n:
+            return bytes(b'')
+        assert (addr & 0xFFFFFC00) == ((addr + n - 1) & 0xFFFFFC00)
+        cmd = pack('<BBIHB', 0xF2, 0x0C, addr, n, ap_num)
+        rsp = self._usb_xfer_in(cmd, 2 if n == 1 else n)
+        err = self._usb_last_xfer_status()
+        if err[0] != 0x80:
+            raise Exception('Unexpected error 0x%02X: %s' % (err[0], err))
+        return bytes(rsp[:n])
+
+    def _bulk_read_16(self, addr, n, ap_num=0):
+        '''
+        Reads a consecutive number of 16-bit halfwords from the 16-bit aligned
+        addr.
+        '''
+        assert self.ver_jtag >= 26
+        assert addr % 2 == 0
+        if not n:
+            return bytes(b'')
+        assert (addr & 0xFFFFFC00) == ((addr + n*2 - 1) & 0xFFFFFC00)
+        cmd = pack('<BBIHB', 0xF2, 0x47, addr, n*2, ap_num)
+        rsp = self._usb_xfer_in(cmd, n*2)
+        err = self._usb_last_xfer_status()
+        if err[0] != 0x80:
+            raise Exception('Unexpected error 0x%02X: %s' % (err[0], err))
+        return bytes(rsp)
+
+    def _bulk_read_32(self, addr, n, ap_num=0):
+        '''
+        Reads a consecutive number of 32-bit words from the 32-bit aligned addr.
+        '''
+        assert addr % 4 == 0
+        if not n:
+            return bytes(b'')
+        assert (addr & 0xFFFFFC00) == ((addr + n*4 - 1) & 0xFFFFFC00)
+        cmd = pack('<BBIHB', 0xF2, 0x07, addr, n*4, ap_num)
+        rsp = self._usb_xfer_in(cmd, n*4)
+        err = self._usb_last_xfer_status()
+        if err[0] != 0x80:
+            raise Exception('Unexpected error 0x%02X: %s' % (err[0], err))
+        return bytes(rsp)
+
+    def _bulk_write_8(self, data, addr, ap_num=0):
+        '''
+        Writes a consecutive number of bytes to the specified address.
+        '''
+        assert len(data) <= 64
+        if not data:
+            return
+        assert (addr & 0xFFFFFC00) == ((addr + len(data) - 1) & 0xFFFFFC00)
+        self._usb_xfer_out(pack('<BBIHB', 0xF2, 0x0D, addr, len(data), ap_num),
+                           data)
+
+    def _bulk_write_16(self, data, addr, ap_num=0):
+        '''
+        Writes a consecutive number of 16-bit halfwords to the 16-bit aligned
+        addr.
+        '''
+        assert self.ver_jtag >= 26
+        assert addr % 2 == 0
+        assert len(data) % 2 == 0
+        if not data:
+            return
+        assert (addr & 0xFFFFFC00) == ((addr + len(data) - 1) & 0xFFFFFC00)
+        self._usb_xfer_out(pack('<BBIHB', 0xF2, 0x48, addr, len(data), ap_num),
+                           data)
+
+    def _bulk_write_32(self, data, addr, ap_num=0):
+        '''
+        Writes a consecutive number of 32-bit words to the 32-bit aligned addr.
+        '''
+        assert addr % 4 == 0
+        assert len(data) % 4 == 0
+        if not data:
+            return
+        assert (addr & 0xFFFFFC00) == ((addr + len(data) - 1) & 0xFFFFFC00)
+        self._usb_xfer_out(pack('<BBIHB', 0xF2, 0x08, addr, len(data), ap_num),
+                           data)
+
+    def _should_offload_ap(self, ap_num):
+        '''
+        Decide whether or not we should offload AP accesses to the debug probe.
+        If there is no populated AP then we have to offload since we don't have
+        a class instance to maintain the AP state; otherwise, if there is an AP
+        and we've detected it to be an AHBAP then it's safe to offload to the
+        probe.  For other types of AP, the debug probe will clobber the upper
+        bits of the CSW register and this can have bad side effects such as
+        preventing the CPU from accessing debug hardware (i.e. by clearing
+        CSW.DbgSwEnable).
+        '''
+        ap = self.aps.get(ap_num)
+        return ap and isinstance(ap, psdb.access_port.AHBAP)
+
+    def assert_srst(self):
+        '''Holds the target in reset.'''
+        self._cmd_allow_retry(bytes(b'\xF2\x3C\x00'), 2)
+
+    def deassert_srst(self):
+        '''Releases the target from reset.'''
+        self._cmd_allow_retry(bytes(b'\xF2\x3C\x01'), 2)
+
+    def set_tck_freq(self, freq):
+        '''
+        Sets the TCK to the nearest frequency that doesn't exceed the
+        requested one.  Returns the actual frequency in Hz.
+        According to OCD divisors map to frequencies as follows:
+                    | OCD  | Scope
+            Divisor | kHz  |  kHz
+            --------+------+------
+                  0 | 4000 | 2360
+                  1 | 1800 | 1553
+                  2 | 1200 | 1230
+                  3 |  950 |  960
+                  7 |  480 |  484
+                 15 |  240 |  245
+                 31 |  125 |  123
+                 40 |  100 |
+                 79 |   50 |
+                158 |   25 |
+                265 |   15 |
+                798 |    5 |
+            --------+------+------
+
+        Basically the clock is crap.  We'll just go with the OCD table.
+        '''
+        freq_map = [(4000000,   0),
+                    (1800000,   1),
+                    (1200000,   2),
+                    ( 950000,   3),
+                    ( 480000,   7),
+                    ( 240000,  15),
+                    ( 125000,  31),
+                    ( 100000,  40),
+                    (  50000,  79),
+                    (  25000, 158),
+                    (  15000, 265),
+                    (   5000, 798)]
+        for f, d in freq_map:
+            if freq >= f:
+                self._set_swdclk_divisor(d)
+                return f
+        raise Exception('Frequency %s too low!' % freq)
+
+    def read_ap_reg(self, apsel, addr):
+        '''Read a 32-bit register from the AP address space.'''
+        cmd = pack('<BBHB', 0xF2, 0x45, apsel, addr)
+        rsp = self._cmd_allow_retry(cmd, 8)
+        return unpack_from('<I', rsp, 4)[0]
+
+    def write_ap_reg(self, apsel, addr, value):
+        '''Write a 32-bit register in the AP address space.'''
+        cmd = pack('<BBHHI', 0xF2, 0x46, apsel, addr, value)
+        self._cmd_allow_retry(cmd, None)
+
+    def read_32(self, addr, ap_num=0):
+        '''
+        Reads a 32-bit word from the 32-bit aligned addr.  This is more
+        efficient than using _bulk_read_32() since the error is returned
+        atomically in the same transaction.
+        '''
+        if not self._should_offload_ap(ap_num):
+            return self.aps[ap_num]._read_32(addr)
+
+        assert addr % 4 == 0
+        cmd = pack('<BBIB', 0xF2, 0x36, addr, ap_num)
+        return unpack_from('<I', self._cmd_allow_retry(cmd, 8), 4)[0]
+
+    def read_16(self, addr, ap_num=0):
+        '''
+        Reads a 16-bit word using the 16-bit bulk read command.
+        For this to make much sense you'll probably want to use a 16-bit
+        aligned address.  Not tested across 32-bit word boundaries.
+        '''
+        if not self._should_offload_ap(ap_num):
+            return self.aps[ap_num]._read_16(addr)
+        return unpack_from('<H', self._bulk_read_16(addr, 1, ap_num=ap_num))[0]
+
+    def read_8(self, addr, ap_num=0):
+        '''
+        Reads an 8-bit value using the 8-bit bulk read command.  Unclear
+        whether or not this actually performs a single 8-bit access since the
+        8-bit bulk read actually returns 2 bytes if you do a single-byte read.
+        '''
+        if not self._should_offload_ap(ap_num):
+            return self.aps[ap_num]._read_8(addr)
+        return (unpack_from('<H', self._bulk_read_8(addr, 1, ap_num=ap_num))[0]
+                & 0xFF)
+
+    def read_bulk(self, addr, size, ap_num=0):
+        '''
+        Do a bulk read operation from the specified address.  If the start or
+        end addresses are not word-aligned then multiple transactions will take
+        place.  If the address range crosses a 1K page boundary, multiple
+        transactions will take place to handle the TAR auto-increment issue.
+        '''
+        if not self._should_offload_ap(ap_num):
+            return self.aps[ap_num]._read_bulk(addr, size)
+        return super(STLinkV2_1, self).read_bulk(addr, size, ap_num)
+
+    def write_32(self, v, addr, ap_num=0):
+        '''
+        Writes a single 32-bit word to the 32-bit aligned addr.  This is more
+        efficient than using _bulk_write_32() since it requires fewer USB
+        transactions.
+        '''
+        if not self._should_offload_ap(ap_num):
+            return self.aps[ap_num]._write_32(v, addr)
+
+        assert addr % 4 == 0
+        cmd = pack('<BBIIB', 0xF2, 0x35, addr, v, ap_num)
+        self._cmd_allow_retry(cmd, 2)
+
+    def write_16(self, v, addr, ap_num=0):
+        '''
+        Writes a 16-bit value using the 16-bit bulk write command.
+        '''
+        if not self._should_offload_ap(ap_num):
+            return self.aps[ap_num]._write_16(v, addr)
+        self._bulk_write_16(pack('<H', v), addr, ap_num)
+
+    def write_8(self, v, addr, ap_num=0):
+        '''
+        Writes an 8-bit value using the 8-bit bulk read command.
+        '''
+        if not self._should_offload_ap(ap_num):
+            return self.aps[ap_num]._write_8(v, addr)
+        self._bulk_write_8(chr(v), addr, ap_num)
+
+    def write_bulk(self, data, addr, ap_num=0):
+        '''
+        Bulk-writes memory by offloading it to the debug probe.  Currently only
+        aligned 32-bit accesses are allowed.
+        '''
+        if not self._should_offload_ap(ap_num):
+            return self.aps[ap_num]._write_bulk(data, addr)
+        super(STLinkV2_1, self).write_bulk(data, addr, ap_num)
+
+    def probe(self, verbose=False):
+        self._swd_connect()
+        self.dpidr = self._read_dpidr()
+        return super(STLinkV2_1, self).probe(verbose=verbose)
+
+    def show_info(self):
+        super(STLinkV2_1, self).show_info()
+        print(' Firmware Ver: V%uJ%uM%u' % (self.ver_stlink, self.ver_jtag,
+                                            self.ver_swim))
+
+
+def enumerate():
+    devices = usb.core.find(find_all=True, idVendor=0x0483, idProduct=0x374B)
+    return [STLinkV2_1(d) for d in devices]

--- a/psdb/scan_tool.py
+++ b/psdb/scan_tool.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2019 Phase Advanced Sensor Systems, Inc.
+import psdb.probes
+
+import sys
+
+
+def main(rv):
+    for p in psdb.probes.PROBES:
+        p.show_info()
+        p.probe(verbose=True).resume()
+
+
+if __name__ == '__main__':
+    try:
+        main(None)
+    except psdb.probes.Exception as e:
+        print(e)
+        sys.exit(1)

--- a/psdb/targets/__init__.py
+++ b/psdb/targets/__init__.py
@@ -3,10 +3,12 @@ from .target import (Target, MemRegion)
 from .device import Reg, MemDevice
 from . import msp432
 from . import stm32h7
+from . import stm32g4
 
 
 TARGETS = [msp432.MSP432P401,
            stm32h7.STM32H7,
+           stm32g4.STM32G4,
            ]
 
 def probe(db):

--- a/psdb/targets/__init__.py
+++ b/psdb/targets/__init__.py
@@ -2,9 +2,10 @@
 from .target import (Target, MemRegion)
 from .device import Reg, MemDevice
 from . import msp432
+from . import stm32h7
 
 
-TARGETS = [msp432.MSP432P401]
+TARGETS = [msp432.MSP432P401, stm32h7.STM32H7]
 
 def probe(db):
     for t in TARGETS:

--- a/psdb/targets/__init__.py
+++ b/psdb/targets/__init__.py
@@ -5,7 +5,9 @@ from . import msp432
 from . import stm32h7
 
 
-TARGETS = [msp432.MSP432P401, stm32h7.STM32H7]
+TARGETS = [msp432.MSP432P401,
+           stm32h7.STM32H7,
+           ]
 
 def probe(db):
     for t in TARGETS:

--- a/psdb/targets/device.py
+++ b/psdb/targets/device.py
@@ -42,11 +42,11 @@ class Reg32W(Reg):
 
 
 class Device(object):
-    def __init__(self, target, base, name, regs):
-        self.target = target
-        self.base   = base
-        self.name   = name
-        self.regs   = regs
+    def __init__(self, target, dev_base, name, regs):
+        self.target   = target
+        self.dev_base = dev_base
+        self.name     = name
+        self.regs     = regs
         for r in regs:
             n = r.name.lower()
             if r.flags & Reg.READABLE:
@@ -61,10 +61,10 @@ class Device(object):
         self.target.devs[self.name] = self
 
     def _read_32(self, offset):
-        return self.target.ahb_ap.read_32(self.base + offset)
+        return self.target.ahb_ap.read_32(self.dev_base + offset)
 
     def _write_32(self, v, offset):
-        self.target.ahb_ap.write_32(v, self.base + offset)
+        self.target.ahb_ap.write_32(v, self.dev_base + offset)
 
     def _set_field(self, v, width, shift, offset):
         assert width + shift <= 32

--- a/psdb/targets/flash.py
+++ b/psdb/targets/flash.py
@@ -106,8 +106,6 @@ class Flash(object):
 
         Data written to sectors outside flash boundaries is silently discarded.
         '''
-        t0 = time.time()
-
         bd = RAMBD(self.sector_size,
                    first_block=self.mem_base // self.sector_size,
                    nblocks=self.nsectors)
@@ -120,9 +118,10 @@ class Flash(object):
         mask = 0
         for block in bd.blocks.values():
             mask |= self._mask_for_alp(block.addr, len(block.data))
-
-        total_len = 0
         self.erase_sectors(mask)
+
+        t0 = time.time()
+        total_len = 0
         for block in bd.blocks.values():
             while block.data.endswith(b'\xff'*64):
                 block.data = block.data[:-64]

--- a/psdb/targets/flash.py
+++ b/psdb/targets/flash.py
@@ -77,11 +77,17 @@ class Flash(Device):
         '''
         return self.erase(self.base_addr, self.flash_size, verbose=verbose)
 
+    def read(self, addr, length):
+        '''
+        Reads a region from the flash.
+        '''
+        raise NotImplementedError
+
     def read_all(self):
         '''
         Reads the entire flash.
         '''
-        return self.target.cpus[0].read_bulk(self.base_addr, self.flash_size)
+        return self.read(self.base_addr, self.flash_size)
 
     def write(self, addr, data, verbose=True):
         '''
@@ -139,7 +145,7 @@ class Flash(Device):
             if verbose:
                 print('Verifying [0x%08X : 0x%08X]...' % (
                       block.addr, block.addr + len(block.data) - 1))
-            mem = self.target.cpus[0].read_bulk(block.addr, len(block.data))
+            mem = self.read(block.addr, len(block.data))
             assert mem == block.data
         if verbose:
             elapsed = time.time() - t0

--- a/psdb/targets/msp432/flctl.py
+++ b/psdb/targets/msp432/flctl.py
@@ -172,7 +172,7 @@ class FLCTL(Device, Flash):
 
         verify_bits = (1 << 7) | (1 << 6)
         for _ in range(self.max_programming_pulses):
-            self.target.ahb_ap.write_bulk(data_bytes, self.base + 0x60)
+            self.target.ahb_ap.write_bulk(data_bytes, self.dev_base + 0x60)
             self._write_prgbrst_startaddr(addr)
             self._write_prgbrst_ctlstat(verify_bits | (4 << 3) | 1)
             ctlstat = self._wait_prgbrst_complete()

--- a/psdb/targets/msp432/flctl.py
+++ b/psdb/targets/msp432/flctl.py
@@ -371,6 +371,12 @@ class FLCTL(flash.Flash):
         assert 0 <= n and n < self.nsectors
         self.erase_sectors(1 << n, verbose)
 
+    def read(self, addr, length):
+        '''
+        Reads a region from the flash.
+        '''
+        return self.target.ahb_ap.read_bulk(addr, length)
+
     def write(self, addr, data, verbose=True):
         '''
         Writes data to flash.  The data must be 16-byte aligned and be a

--- a/psdb/targets/stm32g4/__init__.py
+++ b/psdb/targets/stm32g4/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2019 Phase Advanced Sensor Systems, Inc.
+from .stm32g4 import STM32G4

--- a/psdb/targets/stm32g4/flash.py
+++ b/psdb/targets/stm32g4/flash.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2019 Phase Advanced Sensor Systems, Inc.
+from ..device import Device, Reg32, Reg32W
+from ..flash import Flash
+
+
+class UnlockedContextManager(object):
+    def __init__(self, flash):
+        self.flash = flash
+
+    def __enter__(self):
+        v = self.flash._read_cr()
+        if v & (1<<31):
+            self.flash._write_keyr(0x45670123)
+            self.flash._write_keyr(0xCDEF89AB)
+
+    def __exit__(self, type, value, traceback):
+        v = self.flash._read_cr()
+        self.flash._write_cr(v | (1<<31))
+
+
+class FLASH(Device, Flash):
+    '''
+    Driver for the FLASH device on the STM32G4 series of MCUs.
+    '''
+    REGS = [Reg32 ('ACR',           0x000),
+            Reg32 ('PDKEYR',        0x004),
+            Reg32W('KEYR',          0x008),
+            Reg32W('OPTKEYR',       0x00C),
+            Reg32 ('SR',            0x010),
+            Reg32 ('CR',            0x014),
+            Reg32 ('ECCR',          0x018),
+            Reg32 ('OPTR',          0x020),
+            Reg32 ('PCROP1SR',      0x024),
+            Reg32 ('PCROP1ER',      0x028),
+            Reg32 ('WRP1AR',        0x02C),
+            Reg32 ('WRP1BR',        0x030),
+            Reg32 ('PCROP2SR',      0x044),
+            Reg32 ('PCROP2ER',      0x048),
+            Reg32 ('WRP2AR',        0x04C),
+            Reg32 ('WRP2BR',        0x050),
+            Reg32 ('SEC1R',         0x070),
+            Reg32 ('SEC2R',         0x074),
+            ]
+
+    def __init__(self, target, name, dev_base, mem_base):
+        Device.__init__(self, target, dev_base, name, FLASH.REGS)
+        optr        = self._read_optr()
+        if optr == 0:
+            raise Exception('Unexpected OPTR=0, debug clocks may be disabled; '
+                            'try using --srst')
+        sector_size = 2048 if optr & (1<<22) else 4096
+        Flash.__init__(self, mem_base, sector_size,
+                       target.flash_size // sector_size)
+
+    def _flash_unlocked(self):
+        return UnlockedContextManager(self)
+
+    def _clear_errors(self):
+        self._write_sr(self._read_sr())
+
+    def _check_errors(self):
+        v = self._read_sr()
+        if v & 0x0000C3F8:
+            raise Exception('Flash operation failed, FLASH_SR=0x%08X' % v)
+
+    def _wait_bsy_clear(self):
+        while self._read_sr() & (1 << 16):
+            pass
+
+    def erase_sector(self, n, verbose=True):
+        '''
+        Erases the nth sector in flash.
+        The sector is verified to be erased before returning.
+        '''
+        assert 0 <= n and n < self.nsectors
+        
+        addr = self.mem_base + n * self.sector_size
+        if verbose:
+            print('Erasing sector [0x%08X - 0x%08X]...' % (
+                    addr, addr + self.sector_size - 1))
+
+        with self._flash_unlocked():
+            self._clear_errors()
+            self._write_cr((n << 3) | (1 << 1))
+            self._write_cr((1 << 16) | (n << 3) | (1 << 1))
+            self._wait_bsy_clear()
+            self._check_errors()
+
+    def read(self, addr, length):
+        '''
+        Reads a region from the flash.
+        '''
+        return self.target.ahb_ap.read_bulk(addr, length)
+
+    def write(self, addr, data, verbose=True):
+        '''
+        Writes 8-byte lines of data to the flash.  The address must be
+        8-byte aligned and the data to write must be a multiple of 8 bytes in
+        length.
+
+        The target region to be written must be in the erased state.
+        '''
+        assert self.target.is_halted()
+        if not data:
+            return
+        assert len(data) % 8 == 0
+        assert addr % 8 == 0
+        assert self.mem_base <= addr
+        assert addr + len(data) <= self.mem_base + self.flash_size
+
+        if verbose:
+            print('Flashing region [0x%08X - 0x%08X]...' % (
+                    addr, addr + len(data) - 1))
+
+        with self._flash_unlocked():
+            self._clear_errors()
+            self._write_cr(1 << 0)
+            self.target.ahb_ap.write_bulk(data, addr)
+            self._wait_bsy_clear()
+            self._check_errors()

--- a/psdb/targets/stm32g4/stm32g4.py
+++ b/psdb/targets/stm32g4/stm32g4.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2019 Phase Advanced Sensor Systems, Inc.
+import psdb
+from .flash import FLASH
+from ..device import MemDevice
+from psdb.targets import Target
+
+
+class STM32G4(Target):
+    def __init__(self, db):
+        super(STM32G4, self).__init__(db)
+        self.ahb_ap     = self.db.aps[0]
+        self.uuid       = self.ahb_ap.read_bulk(0x1FFF7590, 12)
+        self.flash_size = (self.ahb_ap.read_32(0x1FFF75E0) & 0x0000FFFF)*1024
+        self.mcu_idcode = self.ahb_ap.read_32(0xE0042000)
+        self.flash      = FLASH(self, 'FLASH', 0x40022000, 0x00000000)
+        MemDevice(self, 'FBANKS', self.flash.mem_base, self.flash.flash_size)
+
+    def __repr__(self):
+        return 'STM32G4 MCU_IDCODE 0x%08X' % self.mcu_idcode
+
+    @staticmethod
+    def probe(db):
+        # APSEL 0 should be populated.
+        if 0 not in db.aps:
+            return None
+
+        # APSEL 0 should be an AHB AP.
+        ap = db.aps[0]
+        if not isinstance(ap, psdb.access_port.AHBAP):
+            return None
+
+        # Identify the STM32G4 through the base component's CIDR/PIDR
+        # registers.
+        c = db.aps[0].base_component
+        if not c or c.cidr != 0xB105100D or c.pidr != 0x00000000000A0469:
+            return None
+
+        # There should be exactly one CPU.
+        if len(db.cpus) != 1:
+            return None
+
+        return STM32G4(db)

--- a/psdb/targets/stm32h7/__init__.py
+++ b/psdb/targets/stm32h7/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2019 Phase Advanced Sensor Systems, Inc.
+from .stm32h7 import STM32H7

--- a/psdb/targets/stm32h7/flash.py
+++ b/psdb/targets/stm32h7/flash.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2018-2019 Phase Advanced Sensor Systems, Inc.
+from ..device import Device, Reg32, Reg32R, Reg32W
+from ..flash import Flash
+
+
+class FlashBank(Device):
+    '''
+    Driver for a single flash bank.
+    '''
+    REGS = [Reg32W('KEYR',      0x004),
+            Reg32 ('CR',        0x00C),
+            Reg32 ('SR',        0x010),
+            Reg32W('CCR',       0x014),
+            Reg32R('PRAR_CUR',  0x028),
+            Reg32 ('PRAR_PRG',  0x02C),
+            Reg32R('SCAR_CUR',  0x030),
+            Reg32 ('SCAR_PRG',  0x034),
+            Reg32R('WPSN_CURR', 0x038),
+            Reg32 ('WPSN_PRGR', 0x03C),
+            Reg32 ('CRCCR',     0x050),
+            Reg32 ('CRCSADDR',  0x054),
+            Reg32 ('CRCEADDR',  0x058),
+            Reg32R('ECC_FAR',   0x060),
+            ]
+
+    def __init__(self, flash, bank_num):
+        Device.__init__(self, flash.target, flash.dev_base + 0x100*bank_num,
+                        '%s.%u' % (flash.name, bank_num), FlashBank.REGS)
+
+    def _clear_errors(self):
+        self._write_ccr(0x0FEF0000)
+
+    def _check_errors(self):
+        v = self._read_sr()
+        if v & 0x0FEE0000:
+            raise Exception('Flash operation failed, FLASH_SR=0x%08X' % v)
+
+    def _wait_prg_idle(self):
+        while self._read_sr() & 7:
+            pass
+
+    def _pg_unlock(self):
+        v = self._read_cr()
+        if v & 1:
+            self._write_keyr(0x45670123)
+            self._write_keyr(0xCDEF89AB)
+            v = self._read_cr()
+            assert not (v & 1)
+        if not (v & 2):
+            self._write_cr(v | 2)
+
+        return self
+
+    def _pg_lock(self):
+        v = self._read_cr()
+        self._write_cr((v & ~2) | 1)
+
+
+class UnlockedContextManager(object):
+    def __init__(self, bank):
+        self.bank = bank
+
+    def __enter__(self):
+        self.bank._pg_unlock()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.bank._pg_lock()
+
+
+class FLASH(Device, Flash):
+    '''
+    Driver for the FLASH device on the STM32H7xx series of MCUs.
+    '''
+    REGS = [Reg32 ('ACR',           0x000),
+            Reg32W('KEYR1',         0x004),
+            Reg32W('OPTKEYR',       0x008),
+            Reg32 ('CR1',           0x00C),
+            Reg32 ('SR1',           0x010),
+            Reg32W('CCR1',          0x014),
+            Reg32 ('OPTCR',         0x018),
+            Reg32 ('OPTSR_CUR',     0x01C),
+            Reg32 ('OPTSR_PRG',     0x020),
+            Reg32 ('OPTCCR',        0x024),
+            Reg32R('PRAR_CUR1',     0x028),
+            Reg32 ('PRAR_PRG1',     0x02C),
+            Reg32R('SCAR_CUR1',     0x030),
+            Reg32 ('SCAR_PRG1',     0x034),
+            Reg32R('WPSN_CUR1R',    0x038),
+            Reg32 ('WPSN_PRG1R',    0x03C),
+            Reg32R('BOOT_CURR',     0x040),
+            Reg32 ('BOOT_PRGR',     0x044),
+            Reg32 ('CRCCR1',        0x050),
+            Reg32 ('CRCSADD1R',     0x054),
+            Reg32 ('CRCEADD1R',     0x058),
+            Reg32R('CRCDATAR',      0x05C),
+            Reg32R('ECC_FA1R',      0x060),
+            Reg32W('KEYR2',         0x104),
+            Reg32 ('CR2',           0x10C),
+            Reg32 ('SR2',           0x110),
+            Reg32W('CCR2',          0x114),
+            Reg32R('PRAR_CUR2',     0x128),
+            Reg32 ('PRAR_PRG2',     0x12C),
+            Reg32R('SCAR_CUR2',     0x130),
+            Reg32 ('SCAR_PRG2',     0x134),
+            Reg32R('WPSN_CUR2R',    0x138),
+            Reg32 ('WPSN_PRG2R',    0x13C),
+            Reg32 ('CRCCR2',        0x150),
+            Reg32 ('CRCSADD2R',     0x154),
+            Reg32 ('CRCEADD2R',     0x158),
+            Reg32R('ECC_FA2R',      0x160),
+            ]
+
+    def __init__(self, target, name, dev_base, mem_base):
+        sector_size = 128*1024
+        Device.__init__(self, target, dev_base, name, FLASH.REGS)
+        Flash.__init__(self, mem_base, sector_size,
+                       target.flash_size // sector_size)
+        nbanks                = 1 if target.flash_size == 128*1024 else 2
+        self.banks            = [FlashBank(self, i) for i in range(nbanks)]
+        self.sectors_per_bank = self.nsectors // nbanks
+        self.bank_size        = self.sector_size * self.sectors_per_bank
+
+    def _flash_bank_unlocked(self, bank):
+        return UnlockedContextManager(bank)
+
+    def erase_sector(self, n, verbose=True):
+        '''
+        Erases the nth sector in flash.
+        The sector is verified to be erased before returning.
+        '''
+        assert 0 <= n and n < self.nsectors
+        
+        addr = self.mem_base + n * self.sector_size
+        if verbose:
+            print('Erasing sector [0x%08X - 0x%08X]...' % (
+                    addr, addr + self.sector_size - 1))
+
+        bank = self.banks[n // self.sectors_per_bank]
+        with self._flash_bank_unlocked(bank):
+            bank._clear_errors()
+            v  = bank._read_cr()
+            v |= ((n % self.sectors_per_bank) << 8) | (1 << 7) | (1 << 2)
+            bank._write_cr(v)
+            bank._wait_prg_idle()
+            bank._check_errors()
+
+    def read(self, addr, length):
+        '''
+        Reads a region from the flash.
+        '''
+        return self.target.ahb_ap.read_bulk(addr, length)
+
+    def write(self, addr, data, verbose=True):
+        '''
+        Writes 32-byte lines of data to the flash.  The address must be
+        32-byte aligned and the data to write must be a multiple of 32 bytes in
+        length and should all be contained within one flash bank but may span
+        multiple sectors.
+
+        The target region to be written must be in the erased state.
+        '''
+        assert self.target.is_halted()
+        if not data:
+            return
+        assert len(data) % 32 == 0
+        assert addr % 32 == 0
+        assert (addr & 0xFFF00000) == ((addr + len(data) - 1) & 0xFFF00000)
+        assert self.mem_base <= addr
+        assert addr + len(data) <= self.mem_base + self.flash_size
+
+        if verbose:
+            print('Flashing region [0x%08X - 0x%08X]...' % (
+                    addr, addr + len(data) - 1))
+
+        bank = self.banks[(addr - self.mem_base) // self.bank_size]
+        with self._flash_bank_unlocked(bank):
+            bank._clear_errors()
+            self.target.ahb_ap.write_bulk(data, addr)
+            bank._wait_prg_idle()
+            bank._check_errors()

--- a/psdb/targets/stm32h7/stm32h7.py
+++ b/psdb/targets/stm32h7/stm32h7.py
@@ -22,16 +22,20 @@ class STM32H7(Target):
     def __init__(self, db):
         super(STM32H7, self).__init__(db)
         self.ahb_ap     = self.db.aps[0]
+        self.apbd_ap    = self.db.aps[2]
         self.uuid       = self.ahb_ap.read_bulk(0x1FF1E800, 12)
         self.flash_size = (self.ahb_ap.read_32(0x1FF1E880) & 0x0000FFFF)*1024
+        self.mcu_idcode = self.apbd_ap.read_32(0xE00E1000)
 
     def __repr__(self):
-        return 'STM32H7'
+        return 'STM32H7xx MCU_IDCODE 0x%08X' % self.mcu_idcode
 
     @staticmethod
     def probe(db):
-        # APSEL 0 should be populated.
+        # APSEL 0 and 2 should be populated.
         if 0 not in db.aps:
+            return None
+        if 2 not in db.aps:
             return None
 
         # APSEL 0 should be an AHB AP.

--- a/psdb/targets/stm32h7/stm32h7.py
+++ b/psdb/targets/stm32h7/stm32h7.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2019 Phase Advanced Sensor Systems, Inc.
+import psdb
+from psdb.targets import Target
+
+
+class STM32H7ROMTable1(psdb.component.Component):
+    '''
+    Matcher for the STM32H7 System ROM Table 1.  This ROM table is found on
+    AP2 at address 0xE00E0000.  In order to probe child components on AP2, we
+    need to enable the D1/D3/Trace clocks via DBGMCU_CR.
+    '''
+    def __init__(self, component, subtype):
+        super(STM32H7ROMTable1, self).__init__(component.parent, component.ap,
+                                               component.addr, subtype)
+        self.write_dbgmcu_cr(0x00700000)
+
+    def write_dbgmcu_cr(self, v):
+        self.ap.write_32(v, 0xE00E1004)
+
+
+class STM32H7(Target):
+    def __init__(self, db):
+        super(STM32H7, self).__init__(db)
+        self.ahb_ap     = self.db.aps[0]
+        self.uuid       = self.ahb_ap.read_bulk(0x1FF1E800, 12)
+        self.flash_size = (self.ahb_ap.read_32(0x1FF1E880) & 0x0000FFFF)*1024
+
+    def __repr__(self):
+        return 'STM32H7'
+
+    @staticmethod
+    def probe(db):
+        # APSEL 0 should be populated.
+        if 0 not in db.aps:
+            return None
+
+        # APSEL 0 should be an AHB AP.
+        ap = db.aps[0]
+        if not isinstance(ap, psdb.access_port.AHBAP):
+            return None
+
+        # Identify the STM32H7 through the base component's CIDR/PIDR
+        # registers.
+        c = db.aps[0].base_component
+        if not c or c.cidr != 0xB105100D or c.pidr != 0x00000000000A0450:
+            return None
+
+        # There should be exactly one CPU.
+        if len(db.cpus) != 1:
+            return None
+
+        return STM32H7(db)
+
+
+psdb.component.StaticMatcher(STM32H7ROMTable1, 2, 0xE00E0000,
+                             0xB105100D, 0x00000000000A0450,
+                             subtype='STM32H7 ROM Table 1')

--- a/psdb/targets/stm32h7/stm32h7.py
+++ b/psdb/targets/stm32h7/stm32h7.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2019 Phase Advanced Sensor Systems, Inc.
 import psdb
+from .flash import FLASH
+from ..device import MemDevice
 from psdb.targets import Target
 
 
@@ -26,6 +28,8 @@ class STM32H7(Target):
         self.uuid       = self.ahb_ap.read_bulk(0x1FF1E800, 12)
         self.flash_size = (self.ahb_ap.read_32(0x1FF1E880) & 0x0000FFFF)*1024
         self.mcu_idcode = self.apbd_ap.read_32(0xE00E1000)
+        self.flash      = FLASH(self, 'FLASH', 0x52002000, 0x08000000)
+        MemDevice(self, 'FBANKS', self.flash.mem_base, self.flash.flash_size)
 
     def __repr__(self):
         return 'STM32H7xx MCU_IDCODE 0x%08X' % self.mcu_idcode


### PR DESCRIPTION
-Add support for STM32H7 (tested only with STM32H743ZIT on Nucleo-H743ZI board with embedded STLink V2.1 probe)
-Add support for STM32G4 (tested only with standalone STM32G474CET using MSP432 LaunchPad board's embedded XDS110 probe)

I would test STM32G4 support via the embedded STLink probe, but the H7 Nucleo board doesn't have a compatible debug header and the LaunchPad is just so easy to use.