### PR TITLE
Connect under reset

### DIFF
--- a/psdb/flash_tool.py
+++ b/psdb/flash_tool.py
@@ -24,7 +24,8 @@ def main(rv):
         probe.srst_target()
 
     # Use the probe to detect a target platform.
-    target = probe.probe(verbose=rv.verbose)
+    target = probe.probe(verbose=rv.verbose,
+                         connect_under_reset=rv.connect_under_reset)
     f      = target.set_max_tck_freq()
     print('Set SWD frequency to %.3f MHz' % (f/1.e6))
 
@@ -68,6 +69,7 @@ if __name__ == '__main__':
     parser.add_argument('--usb-path')
     parser.add_argument('--halt', action='store_true')
     parser.add_argument('--srst', action='store_true')
+    parser.add_argument('--connect-under-reset', action='store_true')
     parser.add_argument('--read-flash')
     parser.add_argument('--flash')
     parser.add_argument('--erase', action='store_true')

--- a/psdb/probes/stlink/stlink.py
+++ b/psdb/probes/stlink/stlink.py
@@ -367,7 +367,7 @@ class STLink(usb_probe.Probe):
             return self.aps[ap_num]._write_bulk(data, addr)
         super(STLink, self).write_bulk(data, addr, ap_num)
 
-    def probe(self, verbose=False):
+    def probe(self, **kwargs):
         self._swd_connect()
         self.dpidr = self._read_dpidr()
-        return super(STLink, self).probe(verbose=verbose)
+        return super(STLink, self).probe(**kwargs)


### PR DESCRIPTION
Allow connecting to the target while asserting SRST and then immediately halting in the Reset vector when we release SRST.  This is really helpful when trying to connect to targets that are stuck in a __wfi() loop and won't respond to the debug port.