### PR TITLE
xds110.py: Also allow XDS110 to connect under reset.

### DIFF
--- a/psdb/probes/xds110/xds110.py
+++ b/psdb/probes/xds110/xds110.py
@@ -387,7 +387,7 @@ class XDS110(usb_probe.Probe):
     def write_8(self, v, addr, ap_num=0):
         self._bulk_write_8(bytes([v]), addr, ap_num)
 
-    def probe(self, verbose=False):
+    def probe(self, **kwargs):
         # Deassert SRST in case someone left it asserted.
         self.deassert_srst()
 
@@ -403,7 +403,7 @@ class XDS110(usb_probe.Probe):
         self.cmapi_acquire()
 
         # Probe the target.
-        return super(XDS110, self).probe(verbose=verbose)
+        return super(XDS110, self).probe(**kwargs)
 
     def show_info(self):
         super(XDS110, self).show_info()


### PR DESCRIPTION
Probably doesn't work with an MSP432 target, but it does work when
programming an STM via the ribbon cable.