### PR TITLE
stm32g4: Fix 16-bit timer definitions.

### DIFF
--- a/psdb/targets/stm32g4/general_purpose_timer_16x1.py
+++ b/psdb/targets/stm32g4/general_purpose_timer_16x1.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2019 Phase Advanced Sensor Systems, Inc.
+from ..device import Device, Reg32, Reg32W
+
+
+class GPT16x1(Device):
+    '''
+    Driver for the General-purpose Timer device (GPT) supporting only 16-bit
+    counters and one capture/compare register.
+    '''
+    REGS = [Reg32 ('CR1',    0x000),
+            Reg32 ('CR2',    0x004),
+            Reg32 ('DIER',   0x00C),
+            Reg32 ('SR',     0x010),
+            Reg32W('EGR',    0x014),
+            Reg32 ('CCMR1',  0x018),
+            Reg32 ('CCER',   0x020),
+            Reg32 ('CNT',    0x024),
+            Reg32 ('PSC',    0x028),
+            Reg32 ('ARR',    0x02C),
+            Reg32 ('RCR',    0x030),
+            Reg32 ('CCR1',   0x034),
+            Reg32 ('BDTR',   0x044),
+            Reg32 ('OR1',    0x050),
+            Reg32 ('DTR2',   0x054),
+            Reg32 ('TISEL',  0x05C),
+            Reg32 ('AF1',    0x060),
+            Reg32 ('AF2',    0x064),
+            Reg32 ('DCR',    0x3DC),
+            Reg32 ('DMAR',   0x3E0),
+            ]
+
+    def __init__(self, target, name, addr):
+        super(GPT16x1, self).__init__(target, addr, name, GPT16x1.REGS)

--- a/psdb/targets/stm32g4/general_purpose_timer_16x2.py
+++ b/psdb/targets/stm32g4/general_purpose_timer_16x2.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2019 Phase Advanced Sensor Systems, Inc.
+from ..device import Device, Reg32, Reg32W
+
+
+class GPT16x2(Device):
+    '''
+    Driver for the General-purpose Timer device (GPT) supporting only 16-bit
+    counters and two capture/compare registers.
+    '''
+    REGS = [Reg32 ('CR1',    0x000),
+            Reg32 ('CR2',    0x004),
+            Reg32 ('SMCR',   0x008),
+            Reg32 ('DIER',   0x00C),
+            Reg32 ('SR',     0x010),
+            Reg32W('EGR',    0x014),
+            Reg32 ('CCMR1',  0x018),
+            Reg32 ('CCER',   0x020),
+            Reg32 ('CNT',    0x024),
+            Reg32 ('PSC',    0x028),
+            Reg32 ('ARR',    0x02C),
+            Reg32 ('RCR',    0x030),
+            Reg32 ('CCR1',   0x034),
+            Reg32 ('CCR2',   0x038),
+            Reg32 ('BDTR',   0x044),
+            Reg32 ('DTR2',   0x054),
+            Reg32 ('TISEL',  0x05C),
+            Reg32 ('AF1',    0x060),
+            Reg32 ('AF2',    0x064),
+            Reg32 ('DCR',    0x3DC),
+            Reg32 ('DMAR',   0x3E0),
+            ]
+
+    def __init__(self, target, name, addr):
+        super(GPT16x2, self).__init__(target, addr, name, GPT16x2.REGS)

--- a/psdb/targets/stm32g4/general_purpose_timer_16x4.py
+++ b/psdb/targets/stm32g4/general_purpose_timer_16x4.py
@@ -2,13 +2,14 @@
 from ..device import Device, Reg32, Reg32W
 
 
-class GPT16(Device):
+class GPT16x4(Device):
     '''
     Driver for the General-purpose Timer device (GPT) supporting only 16-bit
-    counters.
+    counters and four capture/compare registers.
     '''
     REGS = [Reg32 ('CR1',    0x000),
             Reg32 ('CR2',    0x004),
+            Reg32 ('SMCR',   0x008),
             Reg32 ('DIER',   0x00C),
             Reg32 ('SR',     0x010),
             Reg32W('EGR',    0x014),
@@ -18,10 +19,11 @@ class GPT16(Device):
             Reg32 ('CNT',    0x024),
             Reg32 ('PSC',    0x028),
             Reg32 ('ARR',    0x02C),
-            Reg32 ('RCR',    0x030),
             Reg32 ('CCR1',   0x034),
-            Reg32 ('BDTR',   0x048),
-            Reg32 ('DTR2',   0x054),
+            Reg32 ('CCR2',   0x038),
+            Reg32 ('CCR3',   0x03C),
+            Reg32 ('CCR4',   0x040),
+            Reg32 ('ECR',    0x058),
             Reg32 ('TISEL',  0x05C),
             Reg32 ('AF1',    0x060),
             Reg32 ('AF2',    0x064),
@@ -30,4 +32,4 @@ class GPT16(Device):
             ]
 
     def __init__(self, target, name, addr):
-        super(GPT16, self).__init__(target, addr, name, GPT16.REGS)
+        super(GPT16x4, self).__init__(target, addr, name, GPT16x4.REGS)

--- a/psdb/targets/stm32g4/stm32g4.py
+++ b/psdb/targets/stm32g4/stm32g4.py
@@ -8,7 +8,9 @@ from .vrefbuf import VREF
 from .gpio import GPIO
 from .dma import DMA
 from .dma_mux import DMAMUX
-from .general_purpose_timer_16 import GPT16
+from .general_purpose_timer_16x1 import GPT16x1
+from .general_purpose_timer_16x2 import GPT16x2
+from .general_purpose_timer_16x4 import GPT16x4
 from .general_purpose_timer_32 import GPT32
 from .advanced_control_timer import ACT
 from .basic_timer import BT
@@ -20,12 +22,12 @@ from ..device import MemDevice
 from psdb.targets import Target
 
 
-DEVICES = [(SRAM,   'CCM SRAM', 0x10000000, 0x00008000),
+DEVICES = [(SRAM,   'CCM SRAM', 0x20018000, 0x00008000),
            (SRAM,   'SRAM1',    0x20000000, 0x00014000),
            (SRAM,   'SRAM2',    0x20014000, 0x00004000),
            (GPT32,  'TIM2',     0x40000000),
-           (GPT32,  'TIM3',     0x40000400),
-           (GPT32,  'TIM4',     0x40000800),
+           (GPT16x4,'TIM3',     0x40000400),
+           (GPT16x4,'TIM4',     0x40000800),
            (GPT32,  'TIM5',     0x40000C00),
            (BT,     'TIM6',     0x40001000),
            (BT,     'TIM7',     0x40001400),
@@ -35,9 +37,9 @@ DEVICES = [(SRAM,   'CCM SRAM', 0x10000000, 0x00008000),
            (OPAMP,  'OPAMP',    0x40010300),
            (ACT,    'TIM1',     0x40012C00),
            (ACT,    'TIM8',     0x40013400),
-           (GPT16,  'TIM15',    0x40014000),
-           (GPT16,  'TIM16',    0x40014400),
-           (GPT16,  'TIM17',    0x40014800),
+           (GPT16x2,'TIM15',    0x40014000),
+           (GPT16x1,'TIM16',    0x40014400),
+           (GPT16x1,'TIM17',    0x40014800),
            (ACT,    'TIM20',    0x40015000),
            (DMA,    'DMA1',     0x40020000),
            (DMA,    'DMA2',     0x40020400),


### PR DESCRIPTION
It turns out there are a few variants of the 16-bit timers that each
have a few different capabilities and registers.  This commit sorts them
all out.