### PR TITLE
ipc: Handle unrecognized WS firmwares gracefully.

### DIFF
--- a/psdb/targets/stm32wb55/ipc/ipc.py
+++ b/psdb/targets/stm32wb55/ipc/ipc.py
@@ -84,7 +84,7 @@ class IPC(object):
     def _make_client(self, stack_type):
         if stack_type == WS_TYPE_BLE_STANDARD:
             return BLEClient(self)
-        raise Exception('No client for WS stack type 0x%02X' % stack_type)
+        return WSClient(self)
 
     def _start_firmware(self, *args):
         t = self.target

--- a/psdb/targets/stm32wb55/ipc/ws_client.py
+++ b/psdb/targets/stm32wb55/ipc/ws_client.py
@@ -9,6 +9,7 @@ class WSClient(object):
         super(WSClient, self).__init__()
         self.ipc = ipc
         assert not self.ipc.mailbox.check_dit_key_fus()
+        self.fw_type = 'WS Generic'
 
     def start_fus_firmware(self):
         '''


### PR DESCRIPTION
This creates a generic class that can still perform operations such as
switching to FUS mode.