### PR TITLE
Libusb package tng

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PSDB_VERS := 1.1.9
+PSDB_VERS := 1.2.0
 PSDB_DEPS := \
 	setup.cfg				\
 	setup.py				\

--- a/psdb/util/pusb.py
+++ b/psdb/util/pusb.py
@@ -13,6 +13,8 @@ def get_backend():
     if not LIBUSB_BACKEND:
         LIBUSB_BACKEND = usb.backend.libusb1.get_backend(
                 find_library=libusb_package_tng.find_library)
+        if LIBUSB_BACKEND is None:
+            LIBUSB_BACKEND = usb.backend.libusb1.get_backend()
     return LIBUSB_BACKEND
 
 

--- a/psdb/util/pusb.py
+++ b/psdb/util/pusb.py
@@ -1,8 +1,8 @@
-# Copyright (c) 2022-2023 by Phase Advanced Sensor Systems, Inc.
+# Copyright (c) 2022-2026 by Phase Advanced Sensor Systems, Inc.
 # All rights reserved.
 import usb.core
 import usb.backend.libusb1
-import libusb_package
+import libusb_package_tng
 
 
 LIBUSB_BACKEND = None
@@ -12,7 +12,7 @@ def get_backend():
     global LIBUSB_BACKEND
     if not LIBUSB_BACKEND:
         LIBUSB_BACKEND = usb.backend.libusb1.get_backend(
-                find_library=libusb_package.find_library)
+                find_library=libusb_package_tng.find_library)
     return LIBUSB_BACKEND
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ packages =
 install_requires =
     btype>=0.1.4
     libusb_package_tng
+    numpy
     pyelftools
     pyusb
     tgcurses>=0.9.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ packages =
     psdb.util
 install_requires =
     btype>=0.1.4
-    libusb_package>=1.0.26.2
+    libusb_package_tng
     pyelftools
     pyusb
     tgcurses>=0.9.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = psdb
-version = 1.1.9
+version = 1.2.0
 author = Terry Greeniaus
 author_email = terrygreeniaus@gmail.com
 description = Package for interfacing with ARM-compatible debug probes

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ license_file = LICENSE
 classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)
 
 [options]
 python_requires = >=3.0


### PR DESCRIPTION
Update to libusb_package_tng so that psdb can run on Python 3.14 and later.